### PR TITLE
fix: replace white scrollbar on artist page with chevron arrow carousel

### DIFF
--- a/src/components/features/home/PlaylistCarousel.tsx
+++ b/src/components/features/home/PlaylistCarousel.tsx
@@ -1,11 +1,10 @@
-import { useRef, useState, useEffect } from 'react';
 import type { Playlist } from '../../../types/spotify';
 import { HomeSection } from './HomeSection';
 import { Skeleton } from '../../ui/skeleton';
 import { PlaylistCard } from './PlaylistCard';
 import { ScrollArrow } from '../../ui/ScrollArrow';
+import { useCarouselScroll } from '../../../hooks/useCarouselScroll';
 
-const CARD_WIDTH = 168;
 const SKELETON_KEYS = ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8'];
 
 interface PlaylistCarouselProps {
@@ -27,31 +26,7 @@ export function PlaylistCarousel({
   onPlay,
   onPause,
 }: Readonly<PlaylistCarouselProps>) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const updateArrows = () => {
-      setCanScrollLeft(el.scrollLeft > 0);
-      setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-    };
-
-    updateArrows();
-    el.addEventListener('scroll', updateArrows);
-    globalThis.addEventListener('resize', updateArrows);
-    return () => {
-      el.removeEventListener('scroll', updateArrows);
-      globalThis.removeEventListener('resize', updateArrows);
-    };
-  }, [playlists]);
-
-  const scroll = (dir: 'left' | 'right') => {
-    scrollRef.current?.scrollBy({ left: dir === 'left' ? -CARD_WIDTH * 2 : CARD_WIDTH * 2, behavior: 'smooth' });
-  };
+  const { scrollRef, canScrollLeft, canScrollRight, scroll } = useCarouselScroll(playlists);
 
   if (isLoading) {
     return (

--- a/src/components/features/home/PlaylistCarousel.tsx
+++ b/src/components/features/home/PlaylistCarousel.tsx
@@ -1,30 +1,12 @@
 import { useRef, useState, useEffect } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { Playlist } from '../../../types/spotify';
 import { HomeSection } from './HomeSection';
 import { Skeleton } from '../../ui/skeleton';
 import { PlaylistCard } from './PlaylistCard';
+import { ScrollArrow } from '../../ui/ScrollArrow';
 
 const CARD_WIDTH = 168;
 const SKELETON_KEYS = ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8'];
-
-function ScrollArrow({ dir, onClick }: Readonly<{ dir: 'left' | 'right'; onClick: () => void }>) {
-  const isLeft = dir === 'left';
-  const Icon = isLeft ? ChevronLeft : ChevronRight;
-  return (
-    <div
-      className={`absolute ${isLeft ? 'left' : 'right'}-0 top-0 bottom-2 w-16 z-10 flex items-center ${isLeft ? 'justify-start' : 'justify-end'} ${isLeft ? 'bg-gradient-to-r' : 'bg-gradient-to-l'} from-surface to-transparent pointer-events-none`}
-    >
-      <button
-        aria-label={`Scroll ${dir}`}
-        onClick={onClick}
-        className={`pointer-events-auto ${isLeft ? 'ml-1' : 'mr-1'} w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center shadow-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white`}
-      >
-        <Icon className="w-5 h-5 text-text-primary" />
-      </button>
-    </div>
-  );
-}
 
 interface PlaylistCarouselProps {
   title: string;

--- a/src/components/ui/ScrollArrow.tsx
+++ b/src/components/ui/ScrollArrow.tsx
@@ -16,6 +16,7 @@ export function ScrollArrow({ dir, onClick, fromColor = 'from-surface' }: Readon
       <button
         aria-label={`Scroll ${dir}`}
         onClick={onClick}
+        type="button"
         className={`pointer-events-auto ${isLeft ? 'ml-1' : 'mr-1'} w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center shadow-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white`}
       >
         <Icon className="w-5 h-5 text-text-primary" />

--- a/src/components/ui/ScrollArrow.tsx
+++ b/src/components/ui/ScrollArrow.tsx
@@ -1,0 +1,25 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface ScrollArrowProps {
+  dir: 'left' | 'right';
+  onClick: () => void;
+  fromColor?: string;
+}
+
+export function ScrollArrow({ dir, onClick, fromColor = 'from-surface' }: Readonly<ScrollArrowProps>) {
+  const isLeft = dir === 'left';
+  const Icon = isLeft ? ChevronLeft : ChevronRight;
+  return (
+    <div
+      className={`absolute ${isLeft ? 'left' : 'right'}-0 top-0 bottom-2 w-16 z-10 flex items-center ${isLeft ? 'justify-start' : 'justify-end'} ${isLeft ? 'bg-gradient-to-r' : 'bg-gradient-to-l'} ${fromColor} to-transparent pointer-events-none`}
+    >
+      <button
+        aria-label={`Scroll ${dir}`}
+        onClick={onClick}
+        className={`pointer-events-auto ${isLeft ? 'ml-1' : 'mr-1'} w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center shadow-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white`}
+      >
+        <Icon className="w-5 h-5 text-text-primary" />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useCarouselScroll.ts
+++ b/src/hooks/useCarouselScroll.ts
@@ -1,0 +1,34 @@
+import { useRef, useState, useEffect } from 'react';
+
+const CARD_WIDTH = 168;
+
+export function useCarouselScroll(dependency: unknown) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const updateArrows = () => {
+      setCanScrollLeft(el.scrollLeft > 0);
+      setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    };
+
+    updateArrows();
+    el.addEventListener('scroll', updateArrows);
+    globalThis.addEventListener('resize', updateArrows);
+    return () => {
+      el.removeEventListener('scroll', updateArrows);
+      globalThis.removeEventListener('resize', updateArrows);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dependency]);
+
+  const scroll = (dir: 'left' | 'right') => {
+    scrollRef.current?.scrollBy({ left: dir === 'left' ? -CARD_WIDTH * 2 : CARD_WIDTH * 2, behavior: 'smooth' });
+  };
+
+  return { scrollRef, canScrollLeft, canScrollRight, scroll };
+}

--- a/src/pages/ArtistDetail.tsx
+++ b/src/pages/ArtistDetail.tsx
@@ -1,31 +1,14 @@
 import { useRef, useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Play, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Play } from 'lucide-react';
 import { useArtist, useArtistAlbums } from '../hooks/useSpotifyQueries';
 import { usePlaybackControls } from '../hooks/useSpotifyMutations';
 import { ErrorState } from '../components/ui/ErrorState';
 import { ArtistDetailSkeleton } from '../components/features/artist/ArtistDetailSkeleton';
 import { ArtistAlbumCard } from '../components/features/artist/ArtistAlbumCard';
+import { ScrollArrow } from '../components/ui/ScrollArrow';
 
 const CARD_WIDTH = 168;
-
-function ScrollArrow({ dir, onClick }: Readonly<{ dir: 'left' | 'right'; onClick: () => void }>) {
-  const isLeft = dir === 'left';
-  const Icon = isLeft ? ChevronLeft : ChevronRight;
-  return (
-    <div
-      className={`absolute ${isLeft ? 'left' : 'right'}-0 top-0 bottom-2 w-16 z-10 flex items-center ${isLeft ? 'justify-start' : 'justify-end'} ${isLeft ? 'bg-gradient-to-r' : 'bg-gradient-to-l'} from-[#121212] to-transparent pointer-events-none`}
-    >
-      <button
-        aria-label={`Scroll ${dir}`}
-        onClick={onClick}
-        className={`pointer-events-auto ${isLeft ? 'ml-1' : 'mr-1'} w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center shadow-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white`}
-      >
-        <Icon className="w-5 h-5 text-text-primary" />
-      </button>
-    </div>
-  );
-}
 
 export default function ArtistDetail() {
   const { id } = useParams<{ id: string }>();
@@ -120,7 +103,7 @@ export default function ArtistDetail() {
         <section>
           <h2 className="text-text-primary text-2xl font-bold mb-4">Albums</h2>
           <div className="relative overflow-hidden">
-            {canScrollLeft && <ScrollArrow dir="left" onClick={() => scroll('left')} />}
+            {canScrollLeft && <ScrollArrow dir="left" onClick={() => scroll('left')} fromColor="from-[#121212]" />}
             <div
               ref={scrollRef}
               data-testid="albums-scroll-container"
@@ -131,7 +114,7 @@ export default function ArtistDetail() {
                 <ArtistAlbumCard key={album.id} album={album} />
               ))}
             </div>
-            {canScrollRight && <ScrollArrow dir="right" onClick={() => scroll('right')} />}
+            {canScrollRight && <ScrollArrow dir="right" onClick={() => scroll('right')} fromColor="from-[#121212]" />}
           </div>
         </section>
       </div>

--- a/src/pages/ArtistDetail.tsx
+++ b/src/pages/ArtistDetail.tsx
@@ -1,10 +1,31 @@
+import { useRef, useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Play } from 'lucide-react';
+import { Play, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useArtist, useArtistAlbums } from '../hooks/useSpotifyQueries';
 import { usePlaybackControls } from '../hooks/useSpotifyMutations';
 import { ErrorState } from '../components/ui/ErrorState';
 import { ArtistDetailSkeleton } from '../components/features/artist/ArtistDetailSkeleton';
 import { ArtistAlbumCard } from '../components/features/artist/ArtistAlbumCard';
+
+const CARD_WIDTH = 168;
+
+function ScrollArrow({ dir, onClick }: Readonly<{ dir: 'left' | 'right'; onClick: () => void }>) {
+  const isLeft = dir === 'left';
+  const Icon = isLeft ? ChevronLeft : ChevronRight;
+  return (
+    <div
+      className={`absolute ${isLeft ? 'left' : 'right'}-0 top-0 bottom-2 w-16 z-10 flex items-center ${isLeft ? 'justify-start' : 'justify-end'} ${isLeft ? 'bg-gradient-to-r' : 'bg-gradient-to-l'} from-[#121212] to-transparent pointer-events-none`}
+    >
+      <button
+        aria-label={`Scroll ${dir}`}
+        onClick={onClick}
+        className={`pointer-events-auto ${isLeft ? 'ml-1' : 'mr-1'} w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center shadow-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white`}
+      >
+        <Icon className="w-5 h-5 text-text-primary" />
+      </button>
+    </div>
+  );
+}
 
 export default function ArtistDetail() {
   const { id } = useParams<{ id: string }>();
@@ -12,9 +33,37 @@ export default function ArtistDetail() {
   const { data: artist, isLoading: artistLoading, isError: artistError, refetch: refetchArtist } = useArtist(id ?? '');
   const { data: albumsData, isLoading: albumsLoading, isError: albumsError, refetch: refetchAlbums } = useArtistAlbums(id ?? '');
   const { play } = usePlaybackControls();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
 
   const isLoading = artistLoading || albumsLoading;
   const isError = artistError || albumsError;
+
+  const albums = (albumsData?.items ?? []).slice(0, 10);
+  const artistImage = artist?.images?.[0]?.url;
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const updateArrows = () => {
+      setCanScrollLeft(el.scrollLeft > 0);
+      setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    };
+
+    updateArrows();
+    el.addEventListener('scroll', updateArrows);
+    globalThis.addEventListener('resize', updateArrows);
+    return () => {
+      el.removeEventListener('scroll', updateArrows);
+      globalThis.removeEventListener('resize', updateArrows);
+    };
+  }, [albums]);
+
+  const scroll = (dir: 'left' | 'right') => {
+    scrollRef.current?.scrollBy({ left: dir === 'left' ? -CARD_WIDTH * 2 : CARD_WIDTH * 2, behavior: 'smooth' });
+  };
 
   if (isLoading) return <ArtistDetailSkeleton />;
   if (isError || !artist) {
@@ -25,9 +74,6 @@ export default function ArtistDetail() {
       />
     );
   }
-
-  const albums = (albumsData?.items ?? []).slice(0, 10);
-  const artistImage = artist.images?.[0]?.url;
 
   return (
     <div className="flex flex-col min-h-full" data-testid="artist-detail">
@@ -73,12 +119,19 @@ export default function ArtistDetail() {
       <div className="flex-1 bg-[#121212] px-6 py-6">
         <section>
           <h2 className="text-text-primary text-2xl font-bold mb-4">Albums</h2>
-          <div className="overflow-x-auto">
-            <div className="flex flex-row gap-4 pb-4">
+          <div className="relative overflow-hidden">
+            {canScrollLeft && <ScrollArrow dir="left" onClick={() => scroll('left')} />}
+            <div
+              ref={scrollRef}
+              data-testid="albums-scroll-container"
+              className="flex gap-4 overflow-x-auto pb-4"
+              style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+            >
               {albums.map((album) => (
                 <ArtistAlbumCard key={album.id} album={album} />
               ))}
             </div>
+            {canScrollRight && <ScrollArrow dir="right" onClick={() => scroll('right')} />}
           </div>
         </section>
       </div>

--- a/src/pages/ArtistDetail.tsx
+++ b/src/pages/ArtistDetail.tsx
@@ -1,4 +1,3 @@
-import { useRef, useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Play } from 'lucide-react';
 import { useArtist, useArtistAlbums } from '../hooks/useSpotifyQueries';
@@ -7,8 +6,7 @@ import { ErrorState } from '../components/ui/ErrorState';
 import { ArtistDetailSkeleton } from '../components/features/artist/ArtistDetailSkeleton';
 import { ArtistAlbumCard } from '../components/features/artist/ArtistAlbumCard';
 import { ScrollArrow } from '../components/ui/ScrollArrow';
-
-const CARD_WIDTH = 168;
+import { useCarouselScroll } from '../hooks/useCarouselScroll';
 
 export default function ArtistDetail() {
   const { id } = useParams<{ id: string }>();
@@ -16,37 +14,13 @@ export default function ArtistDetail() {
   const { data: artist, isLoading: artistLoading, isError: artistError, refetch: refetchArtist } = useArtist(id ?? '');
   const { data: albumsData, isLoading: albumsLoading, isError: albumsError, refetch: refetchAlbums } = useArtistAlbums(id ?? '');
   const { play } = usePlaybackControls();
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
+  const { scrollRef, canScrollLeft, canScrollRight, scroll } = useCarouselScroll(albumsData?.items);
 
   const isLoading = artistLoading || albumsLoading;
   const isError = artistError || albumsError;
 
   const albums = (albumsData?.items ?? []).slice(0, 10);
   const artistImage = artist?.images?.[0]?.url;
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const updateArrows = () => {
-      setCanScrollLeft(el.scrollLeft > 0);
-      setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-    };
-
-    updateArrows();
-    el.addEventListener('scroll', updateArrows);
-    globalThis.addEventListener('resize', updateArrows);
-    return () => {
-      el.removeEventListener('scroll', updateArrows);
-      globalThis.removeEventListener('resize', updateArrows);
-    };
-  }, [albums]);
-
-  const scroll = (dir: 'left' | 'right') => {
-    scrollRef.current?.scrollBy({ left: dir === 'left' ? -CARD_WIDTH * 2 : CARD_WIDTH * 2, behavior: 'smooth' });
-  };
 
   if (isLoading) return <ArtistDetailSkeleton />;
   if (isError || !artist) {


### PR DESCRIPTION
## Summary

- Removes the native white scrollbar from the artist albums section
- Hides the native scrollbar (`scrollbarWidth: none`) and adds left/right chevron arrow buttons that appear dynamically based on scroll position
- Matches the carousel pattern already used on the home page (`PlaylistCarousel`)

Closes #28

## Test plan

- [ ] Navigate to an artist page with multiple albums — confirm no white scrollbar is visible
- [ ] Confirm a right chevron arrow appears when there are more albums to the right
- [ ] Click the right arrow to scroll — confirm it scrolls smoothly
- [ ] After scrolling right, confirm a left chevron arrow appears
- [ ] Click the left arrow — confirm it scrolls back
- [ ] All 17 existing `ArtistDetail` tests pass

https://claude.ai/code/session_015duffePt3aymjzz7T84rEB